### PR TITLE
Bumped sqlite3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "express": "~4.12.2",
     "jade": "~1.9.2",
-    "sqlite3": "~2.1.1",
+    "sqlite3": "~3.0.x",
     "body-parser": "~1.12.0",
     "compression": "~1.4.3",
     "node-sass": "~3.0.0-alpha.0",


### PR DESCRIPTION
Bumping the [sqlite3](https://www.npmjs.com/package/sqlite3) dependencie version to 3.0.x, as talked about in issue hbons/Lockee#5
